### PR TITLE
Used instanceof instead of is_a

### DIFF
--- a/core/frontend/class-simmer-frontend.php
+++ b/core/frontend/class-simmer-frontend.php
@@ -179,7 +179,7 @@ final class Simmer_Frontend {
 	 */
 	public function open_schema_wrap( $query ) {
 
-		if ( true === $this->schema_wrap_open || ! is_a( $query, 'WP_Query' ) ) {
+		if ( true === $this->schema_wrap_open || ! $query instanceof WP_Query ) {
 			return;
 		}
 
@@ -200,7 +200,7 @@ final class Simmer_Frontend {
 	 */
 	public function close_schema_wrap( $query ) {
 
-		if ( false === $this->schema_wrap_open || ! is_a( $query, 'WP_Query' ) ) {
+		if ( false === $this->schema_wrap_open || ! $query instanceof WP_Query ) {
 			return;
 		}
 


### PR DESCRIPTION
Technically either of these should be fine, but I forgot that PHP deprecated `is_a` in version 5.0.0 and then un-deprecated it (wtf) in 5.3 so anyone on 5.2.x would potentially get a PHP warning when using it.

It also looks like `instanceof` is [a bit faster](http://stackoverflow.com/a/20870004), so that's always good I guess. :confused: 