### PR TITLE
Added a recipe title template tag

### DIFF
--- a/core/frontend/template-functions.php
+++ b/core/frontend/template-functions.php
@@ -35,3 +35,46 @@ function simmer_recipe_has_featured_image( $recipe_id = null ) {
 
 	return $has_featured_image;
 }
+
+/**
+ * Return the title for a recipe.
+ *
+ * @since  1.3.9
+ *
+ * @param  int $recipe_id The ID of the recipe to output the title for.
+ * @return string The recipe's title with a wrapping permalink.
+ */
+function simmer_get_recipe_title( $recipe_id = null ) {
+	if ( null === $recipe_id ) {
+		$recipe_id = get_the_ID();
+	}
+
+	$title = sprintf( '<a href="%s">%s</a>',
+		esc_url( get_permalink( $recipe_id ) ),
+		get_the_title( $recipe_id )
+	);
+
+	/**
+	 * Filter the recipe title's markup.
+	 *
+	 * @since 1.3.9
+	 *
+	 * @param int $recipe_id The ID of the recipe to output the title for.
+	 */
+	return apply_filters( 'simmer_recipe_title', $title, $recipe_id );
+}
+
+/**
+ * Output the title for a recipe.
+ *
+ * @since  1.3.9
+ *
+ * @param  int $recipe_id The ID of the recipe to output the title for.
+ * @return void
+ */
+function simmer_recipe_title( $recipe_id = null ) {
+	if ( null === $recipe_id ) {
+		$recipe_id = get_the_ID();
+	}
+	echo simmer_get_recipe_title( $recipe_id );
+}

--- a/core/frontend/template-functions.php
+++ b/core/frontend/template-functions.php
@@ -2,9 +2,11 @@
 /**
  * Define the front-end template functions
  *
- * @since 1.2.0
- *
- * @package Simmer/Frontend
+ * @package    Simmer
+ * @subpackage Simmer/Frontend
+ * @author     Team Simmer
+ * @copyright  Copyright (c) 2015, Team Simmer
+ * @since      1.2.0
  */
 
 /**
@@ -12,7 +14,7 @@
  *
  * @since 1.2.0
  *
- * @param  int  $recipe_id          Optional. The ID of the recipe to check. Defaults to the currently looped recipe.
+ * @param  int $recipe_id Optional. The ID of the recipe to check. Defaults to the currently looped recipe.
  * @return bool $has_featured_image Whether the recipe's featured image has been set.
  */
 function simmer_recipe_has_featured_image( $recipe_id = null ) {

--- a/core/frontend/templates/recipe-shortcode.php
+++ b/core/frontend/templates/recipe-shortcode.php
@@ -11,7 +11,7 @@
 <div <?php post_class( 'simmer-embedded-recipe' ); ?> itemscope itemtype="http://schema.org/Recipe">
 
 	<h1 class="simmer-recipe-title" itemprop="name">
-		<a href="<?php the_permalink(); ?>"><?php echo esc_html( get_the_title() ); ?></a>
+		<?php simmer_recipe_title(); ?>
 	</h1>
 
 	<div class="simmer-recipe-meta">


### PR DESCRIPTION
The purpose of this is to allow theme and plugin developers to control the output of the title a bit more without overriding the entire recipe template. It's pretty difficult (and unpredictable) to override the template from another plugin, so this helper function aims to make it more straightforward.

This should fix #111. I've also fixed a few WordPress coding standards nags and removed `esc_html` from `get_the_title`. Some HTML elements are allowed in the WordPress title and they would be output incorrectly with `esc_html` applied.